### PR TITLE
Feat: Implement initial Home Screen UI for Food Delivery App

### DIFF
--- a/FoodDeliveryApp/app/build.gradle.kts
+++ b/FoodDeliveryApp/app/build.gradle.kts
@@ -1,0 +1,67 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.fooddeliveryapp"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.fooddeliveryapp"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("io.coil-kt:coil-compose:2.5.0") // Added Coil for image loading
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/FoodDeliveryApp/app/src/main/AndroidManifest.xml
+++ b/FoodDeliveryApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.FoodDeliveryApp"
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.FoodDeliveryApp">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/MainActivity.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.example.fooddeliveryapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import com.example.fooddeliveryapp.ui.screens.HomeScreen // Import HomeScreen
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            FoodDeliveryAppTheme {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    HomeScreen() // Display the HomeScreen
+                }
+            }
+        }
+    }
+}
+// Removed the Greeting composable and its preview as they are no longer needed.

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/data/model/Restaurant.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/data/model/Restaurant.kt
@@ -1,0 +1,63 @@
+package com.example.fooddeliveryapp.data.model
+
+data class Restaurant(
+    val id: String,
+    val name: String,
+    val cuisineTypes: List<String>,
+    val rating: Double,
+    val estimatedDeliveryTime: String, // e.g., "25-35 min"
+    val imageUrl: String? = null, // Placeholder for actual image loading
+    val distance: String? = null, // e.g. "2.5 km"
+    val offers: List<String>? = null // e.g. ["20% OFF", "Free Delivery"]
+)
+
+val sampleRestaurants = listOf(
+    Restaurant(
+        id = "1",
+        name = "The Gourmet Place",
+        cuisineTypes = listOf("Italian", "Pizza"),
+        rating = 4.5,
+        estimatedDeliveryTime = "25-35 min",
+        imageUrl = "https://via.placeholder.com/150/FFC107/000000?Text=Restaurant1",
+        distance = "1.2 km",
+        offers = listOf("20% OFF up to $50")
+    ),
+    Restaurant(
+        id = "2",
+        name = "Burger Queen",
+        cuisineTypes = listOf("Burgers", "Fast Food"),
+        rating = 4.2,
+        estimatedDeliveryTime = "20-30 min",
+        imageUrl = "https://via.placeholder.com/150/4CAF50/FFFFFF?Text=Restaurant2",
+        distance = "0.8 km",
+        offers = listOf("Free Delivery")
+    ),
+    Restaurant(
+        id = "3",
+        name = "Sushi Central",
+        cuisineTypes = listOf("Japanese", "Sushi"),
+        rating = 4.8,
+        estimatedDeliveryTime = "30-40 min",
+        imageUrl = "https://via.placeholder.com/150/E91E63/FFFFFF?Text=Restaurant3",
+        distance = "2.5 km"
+    ),
+    Restaurant(
+        id = "4",
+        name = "Curry House",
+        cuisineTypes = listOf("Indian", "Curry"),
+        rating = 4.6,
+        estimatedDeliveryTime = "35-45 min",
+        imageUrl = "https://via.placeholder.com/150/9C27B0/FFFFFF?Text=Restaurant4",
+        distance = "3.1 km",
+        offers = listOf("Combo Deals Available")
+    ),
+    Restaurant(
+        id = "5",
+        name = "Healthy Bites",
+        cuisineTypes = listOf("Salads", "Smoothies", "Healthy"),
+        rating = 4.3,
+        estimatedDeliveryTime = "15-25 min",
+        imageUrl = "https://via.placeholder.com/150/00BCD4/000000?Text=Restaurant5",
+        distance = "1.0 km"
+    )
+)

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/navigation/AppBottomNavigationBar.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/navigation/AppBottomNavigationBar.kt
@@ -1,0 +1,49 @@
+package com.example.fooddeliveryapp.ui.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+@Composable
+fun AppBottomNavigationBar(
+    items: List<NavigationItem>,
+    currentRoute: String?,
+    onItemSelected: (NavigationItem) -> Unit
+) {
+    NavigationBar {
+        items.forEach { item ->
+            NavigationBarItem(
+                icon = { Icon(item.icon, contentDescription = item.title) },
+                label = { Text(item.title) },
+                selected = currentRoute == item.route,
+                onClick = { onItemSelected(item) },
+                alwaysShowLabel = true // Or false, depending on design preference
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AppBottomNavigationBarPreview() {
+    var currentSelectedItem by remember { mutableStateOf<NavigationItem>(NavigationItem.Home) }
+    FoodDeliveryAppTheme {
+        AppBottomNavigationBar(
+            items = bottomNavItems,
+            currentRoute = currentSelectedItem.route,
+            onItemSelected = { selectedItem ->
+                currentSelectedItem = selectedItem
+                // In a real app, you'd navigate here
+                println("Selected: ${selectedItem.title}")
+            }
+        )
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/navigation/NavigationItem.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/navigation/NavigationItem.kt
@@ -1,0 +1,22 @@
+package com.example.fooddeliveryapp.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Receipt
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class NavigationItem(val route: String, val icon: ImageVector, val title: String) {
+    object Home : NavigationItem("home", Icons.Filled.Home, "Home")
+    object Orders : NavigationItem("orders", Icons.Filled.Receipt, "Orders")
+    object Cart : NavigationItem("cart", Icons.Filled.ShoppingCart, "Cart")
+    object Profile : NavigationItem("profile", Icons.Filled.Person, "Profile")
+}
+
+val bottomNavItems = listOf(
+    NavigationItem.Home,
+    NavigationItem.Orders,
+    NavigationItem.Cart,
+    NavigationItem.Profile
+)

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/HomeScreen.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/HomeScreen.kt
@@ -1,0 +1,120 @@
+package com.example.fooddeliveryapp.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+// Import for PromotionsSection was missing, let's ensure it's here or add it if it was accidentally removed
+import com.example.fooddeliveryapp.ui.screens.composables.PromotionsSection
+import com.example.fooddeliveryapp.ui.screens.composables.CategoryChipsSection
+import com.example.fooddeliveryapp.ui.screens.composables.RestaurantListSection
+import com.example.fooddeliveryapp.ui.navigation.AppBottomNavigationBar // Import Bottom Nav Bar
+import com.example.fooddeliveryapp.ui.navigation.NavigationItem // Import Nav Items
+import com.example.fooddeliveryapp.ui.navigation.bottomNavItems // Import Nav Items List
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen() {
+    var searchText by remember { mutableStateOf(TextFieldValue("")) }
+    var currentScreen by remember { mutableStateOf<NavigationItem>(NavigationItem.Home) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    TextField(
+                        value = searchText,
+                        onValueChange = { searchText = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = 8.dp) // Optional: add some padding if needed
+                            .height(50.dp), // Adjust height as needed
+                        placeholder = { Text("Search restaurants or cuisines...") },
+                        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = "Search Icon") },
+                        colors = TextFieldDefaults.textFieldColors(
+                            cursorColor = MaterialTheme.colorScheme.onSurface,
+                            focusedIndicatorColor = Color.Transparent, // No underline when focused
+                            unfocusedIndicatorColor = Color.Transparent // No underline when not focused
+                        ),
+                        singleLine = true
+                    )
+                }
+                // Optional: Add navigation icon or actions here if needed
+            )
+        },
+        bottomBar = {
+            AppBottomNavigationBar(
+                items = bottomNavItems,
+                currentRoute = currentScreen.route,
+                onItemSelected = { selectedItem ->
+                    currentScreen = selectedItem
+                    // In a real app, this would trigger navigation to the selectedItem.route
+                    // For now, it just updates the state to highlight the selected tab
+                    println("Bottom Nav Clicked: ${selectedItem.title}")
+                }
+            )
+        }
+    ) { innerPadding ->
+        // Based on currentScreen, you would display different content.
+        // For this example, we always show the main home content.
+        // A more robust solution would use a NavHost here.
+        Column(
+            modifier = Modifier
+                .padding(innerPadding) // Apply padding from Scaffold
+                .fillMaxSize()
+        ) {
+            // For now, only Home screen content is shown regardless of bottom nav selection
+            if (currentScreen == NavigationItem.Home) {
+                PromotionsSection(modifier = Modifier.padding(top = 8.dp))
+                CategoryChipsSection(modifier = Modifier.padding(top = 8.dp))
+                RestaurantListSection(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    onRestaurantClick = { restaurant ->
+                        println("Clicked on ${restaurant.name}")
+                    }
+                )
+            } else {
+                // Placeholder for other screens
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Content for ${currentScreen.title}")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    FoodDeliveryAppTheme {
+        HomeScreen()
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/CategoryChipsSection.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/CategoryChipsSection.kt
@@ -1,0 +1,118 @@
+package com.example.fooddeliveryapp.ui.screens.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+data class CategoryChipItem(
+    val id: Int,
+    val name: String
+)
+
+val sampleCategories = listOf(
+    CategoryChipItem(1, "All"),
+    CategoryChipItem(2, "Pizza"),
+    CategoryChipItem(3, "Burgers"),
+    CategoryChipItem(4, "Sushi"),
+    CategoryChipItem(5, "Desserts"),
+    CategoryChipItem(6, "Healthy"),
+    CategoryChipItem(7, "Indian"),
+    CategoryChipItem(8, "Chinese")
+)
+
+@Composable
+fun CategoryChipsSection(
+    categories: List<CategoryChipItem> = sampleCategories,
+    onCategorySelected: (CategoryChipItem) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var selectedCategory by remember { mutableStateOf(categories.firstOrNull()) }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Categories",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(categories) { category ->
+                CategoryChip(
+                    category = category,
+                    isSelected = category == selectedCategory,
+                    onClick = {
+                        selectedCategory = category
+                        onCategorySelected(category)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CategoryChip(
+    category: CategoryChipItem,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium, // Rounded corners
+        colors = ButtonDefaults.buttonColors(
+            containerColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+        ),
+        elevation = ButtonDefaults.buttonElevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 4.dp
+        )
+    ) {
+        Text(text = category.name, style = MaterialTheme.typography.labelMedium)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryChipsSectionPreview() {
+    FoodDeliveryAppTheme {
+        CategoryChipsSection()
+    }
+}
+
+@Preview(showBackground = true, name = "Selected Chip")
+@Composable
+fun CategoryChipSelectedPreview() {
+    FoodDeliveryAppTheme {
+        CategoryChip(category = sampleCategories[1], isSelected = true, onClick = {})
+    }
+}
+
+@Preview(showBackground = true, name = "Unselected Chip")
+@Composable
+fun CategoryChipUnselectedPreview() {
+    FoodDeliveryAppTheme {
+        CategoryChip(category = sampleCategories[2], isSelected = false, onClick = {})
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/PromotionsSection.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/PromotionsSection.kt
@@ -1,0 +1,105 @@
+package com.example.fooddeliveryapp.ui.screens.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+data class PromotionItem(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val backgroundColor: Color
+)
+
+val samplePromotions = listOf(
+    PromotionItem(1, "Flat 20% Off", "On orders above $200", Color.Yellow.copy(alpha = 0.7f)),
+    PromotionItem(2, "Free Delivery", "On selected restaurants", Color.Cyan.copy(alpha = 0.7f)),
+    PromotionItem(3, "Special Combo", "Burger + Fries + Coke at $99", Color.Magenta.copy(alpha = 0.5f)),
+    PromotionItem(4, "Weekend Special", "Pizza BOGO", Color.Green.copy(alpha = 0.6f))
+)
+
+@Composable
+fun PromotionsSection(
+    promotions: List<PromotionItem> = samplePromotions,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Offers For You",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(promotions) { promotion ->
+                PromotionCard(promotion)
+            }
+        }
+    }
+}
+
+@Composable
+fun PromotionCard(promotion: PromotionItem) {
+    Box(
+        modifier = Modifier
+            .width(280.dp)
+            .height(140.dp)
+            .clip(MaterialTheme.shapes.medium)
+            .background(promotion.backgroundColor)
+            .padding(16.dp),
+        contentAlignment = Alignment.CenterStart // Aligns text to the start (left)
+    ) {
+        Column {
+            Text(
+                text = promotion.title,
+                style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp, fontWeight = FontWeight.Bold),
+                color = Color.Black.copy(alpha = 0.8f)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = promotion.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Black.copy(alpha = 0.7f)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PromotionsSectionPreview() {
+    FoodDeliveryAppTheme {
+        PromotionsSection()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PromotionCardPreview() {
+    FoodDeliveryAppTheme {
+        PromotionCard(samplePromotions.first())
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/RestaurantListItem.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/RestaurantListItem.kt
@@ -1,0 +1,170 @@
+package com.example.fooddeliveryapp.ui.screens.composables
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Timer
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import com.example.fooddeliveryapp.data.model.Restaurant
+import com.example.fooddeliveryapp.data.model.sampleRestaurants
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RestaurantListItem(
+    restaurant: Restaurant,
+    onClick: (Restaurant) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = { onClick(restaurant) },
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column {
+            // Restaurant Image - Using Coil for image loading
+            Image(
+                painter = rememberAsyncImagePainter(
+                    ImageRequest.Builder(LocalContext.current)
+                        .data(data = restaurant.imageUrl ?: "https://via.placeholder.com/300x200/CCCCCC/000000?Text=No+Image")
+                        .apply(block = fun ImageRequest.Builder.() {
+                            crossfade(true)
+                            // Можно добавить placeholder/error drawable если нужно
+                        }).build()
+                ),
+                contentDescription = restaurant.name,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp)), // Clip only top corners
+                contentScale = ContentScale.Crop
+            )
+
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = restaurant.name,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = restaurant.cuisineTypes.joinToString(", "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = "Rating",
+                            tint = Color(0xFFFFC107), // Gold color for star
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "${restaurant.rating}",
+                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+                        )
+                        restaurant.distance?.let {
+                            Text(
+                                text = " • $it",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Outlined.Timer,
+                            contentDescription = "Delivery Time",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = restaurant.estimatedDeliveryTime,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+
+                restaurant.offers?.takeIf { it.isNotEmpty() }?.let { offers ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = offers.joinToString(" | "),
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.tertiary, // Use a distinct color for offers
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RestaurantListItemPreview() {
+    FoodDeliveryAppTheme {
+        RestaurantListItem(
+            restaurant = sampleRestaurants.first(),
+            onClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RestaurantListItemWithoutOfferPreview() {
+    FoodDeliveryAppTheme {
+        RestaurantListItem(
+            restaurant = sampleRestaurants[2], // Sushi Central has no offers in sample
+            onClick = {}
+        )
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/RestaurantListSection.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/screens/composables/RestaurantListSection.kt
@@ -1,0 +1,53 @@
+package com.example.fooddeliveryapp.ui.screens.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.fooddeliveryapp.data.model.Restaurant
+import com.example.fooddeliveryapp.data.model.sampleRestaurants
+import com.example.fooddeliveryapp.ui.theme.FoodDeliveryAppTheme
+
+@Composable
+fun RestaurantListSection(
+    restaurants: List<Restaurant> = sampleRestaurants,
+    onRestaurantClick: (Restaurant) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Nearby Restaurants",
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        LazyColumn(
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp) // Spacing between items
+        ) {
+            items(restaurants, key = { it.id }) { restaurant ->
+                RestaurantListItem(
+                    restaurant = restaurant,
+                    onClick = onRestaurantClick
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 600)
+@Composable
+fun RestaurantListSectionPreview() {
+    FoodDeliveryAppTheme {
+        RestaurantListSection(onRestaurantClick = {})
+    }
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Color.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package com.example.fooddeliveryapp.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Theme.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Theme.kt
@@ -1,0 +1,70 @@
+package com.example.fooddeliveryapp.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+
+    /* Other default colors to override
+    background = Color(0xFFFFFBFE),
+    surface = Color(0xFFFFFBFE),
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color(0xFF1C1B1F),
+    onSurface = Color(0xFF1C1B1F),
+    */
+)
+
+@Composable
+fun FoodDeliveryAppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android 12+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Type.kt
+++ b/FoodDeliveryApp/app/src/main/java/com/example/fooddeliveryapp/ui/theme/Type.kt
@@ -1,0 +1,34 @@
+package com.example.fooddeliveryapp.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+    /* Other default text styles to override
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    */
+)

--- a/FoodDeliveryApp/app/src/main/res/values/strings.xml
+++ b/FoodDeliveryApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">FoodDeliveryApp</string>
+</resources>

--- a/FoodDeliveryApp/app/src/main/res/values/themes.xml
+++ b/FoodDeliveryApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.FoodDeliveryApp" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/FoodDeliveryApp/app/src/main/res/xml/backup_rules.xml
+++ b/FoodDeliveryApp/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- TODO: Remove schemaLocation if not using schema. -->
+    <include
+        domain="sharedpref"
+        path="."
+        requireFlags="clientSideEncryption"
+        tools:ignore="FullBackupContentUsage"
+        xmlns:tools="http://schemas.android.com/tools" />
+    <exclude
+        domain="database"
+        path="my_db_impl.db" />
+</full-backup-content>

--- a/FoodDeliveryApp/app/src/main/res/xml/data_extraction_rules.xml
+++ b/FoodDeliveryApp/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <!-- TODO: Remove schemaLocation if not using schema. -->
+        <include
+            domain="sharedpref"
+            path="."
+            requireFlags="clientSideEncryption"
+            tools:ignore="FullBackupContentUsage"
+            xmlns:tools="http://schemas.android.com/tools" />
+        <!-- Exclude specific shared preferences that contain sensitive data. -->
+        <!-- <exclude domain="sharedpref" path="device.xml"/> -->
+    </cloud-backup>
+    <device-transfer>
+        <include
+            domain="sharedpref"
+            path="."
+            requireFlags="clientSideEncryption"
+            tools:ignore="FullBackupContentUsage"
+            xmlns:tools="http://schemas.android.com/tools" />
+        <!-- <exclude domain="sharedpref" path="device.xml"/> -->
+    </device-transfer>
+</data-extraction-rules>

--- a/FoodDeliveryApp/build.gradle.kts
+++ b/FoodDeliveryApp/build.gradle.kts
@@ -1,0 +1,5 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "8.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+}

--- a/FoodDeliveryApp/settings.gradle.kts
+++ b/FoodDeliveryApp/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "FoodDeliveryApp"
+include(":app")


### PR DESCRIPTION
This commit introduces the basic structure and UI elements for the Home Screen of the Android Food Delivery App using Jetpack Compose.

Key features implemented:
- Basic Android project setup with Jetpack Compose.
- HomeScreen composable using Scaffold.
- TopAppBar with an integrated TextField for search functionality.
- Horizontally scrollable PromotionsSection with placeholder cards.
- Horizontally scrollable CategoryChipsSection for filtering.
- Vertically scrollable RestaurantListSection displaying restaurant items with placeholder data and images (using Coil).
- Restaurant data models and sample data.
- Integration of all sections into the HomeScreen.
- MainActivity updated to display the HomeScreen.
- (Stretch Goal) Implemented a BottomNavigationBar with placeholder navigation for Home, Orders, Cart, and Profile.